### PR TITLE
fix: wrong styling in Commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple plugin built for improving the quality of life for builders.
 * `/blockbelt toggle` - Toggles the BlockBelt on or off
 * `/blockbelt reload` - Reloads the BlockBelt config
 * `/blockbelt help` - Shows the help message
-* `/blockbelt hotkey - Toggles the hotkey to open belts
+* `/blockbelt hotkey` - Toggles the hotkey to open belts
 
 ### Have bugs?
 * [Report them here](https://github.com/Frocoa/BlockBelt/issues)


### PR DESCRIPTION
Just a quick fix on the `Commands` section on your README file!